### PR TITLE
Ion core defensive fix

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/weapons/mp_titancore_lasercannon.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/weapons/mp_titancore_lasercannon.nut
@@ -52,6 +52,9 @@ void function LaserCore_OnPlayedOrNPCKilled( entity victim, entity attacker, var
 	entity soul = attacker.GetTitanSoul()
 	if ( !IsValid( soul ) )
 		return
+	//Defensive fix for sometimes npc could delay dead (like nuke titan)
+	if ( soul.GetCoreChargeExpireTime() <= Time() )
+		return
 
 	entity weapon = attacker.GetOffhandWeapon( OFFHAND_EQUIPMENT )
 	if ( !weapon.HasMod( "fd_laser_cannon" ) )


### PR DESCRIPTION
[@liveskai](https://github.com/liveskai) found this bug and its will happened when u using ion core weapon killed a nuke titan npc, if npc dead while core end will get a weird few second active time and icon shows core active but nothing will happened, its will all back to normally when active time end